### PR TITLE
linux-firmware: Address the BalenaOS linux-firmware split issue.

### DIFF
--- a/layers/meta-balena-imx8mplus/recipes-bsp/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-bsp/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,4 @@
+PACKAGES:remove = " ${PN}-iwlwifi-ty-a0 "
+PACKAGES:remove = " ${PN}-iwlwifi-cc-a0 "
+PACKAGES:remove = " ${PN}-ibt-41-41 "
+PACKAGES:remove = " ${PN}-ibt-20-1-3 "


### PR DESCRIPTION
CompuLab provides its own recipe for an ax200 and ax210 Intel wifi: https://github.com/compulab-yokneam/meta-compulab-bsp/blob/kirkstone/meta-bsp/recipes-bsp/linux-firmware/linux-firmware_%25.bbappend

After applying these commits:
https://github.com/balena-os/meta-balena/commit/f54f1988aaa46746c70ad8b4cf63a88218d4f983 https://github.com/balena-os/meta-balena/commit/2ca4f0ebd247db9981d1c488327960cbde9d0e46

the linux-firmware-ax210 created empty;
the linux-firmware-ax200 created with bluetooth firmware files only.

As a result the iotdin-imx8mp balena-image can't work with the CompuLab wifi extension with Intel ax200/ax210.

Changelog-entry: linux-firmware: Remove Balena created wifi packages