### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-imx8mplus/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx8mplus/recipes-core/images/balena-image.inc
@@ -25,3 +25,8 @@ IMAGE_INSTALL:remove = "jailhouse"
 
 CORE_IMAGE_EXTRA_INSTALL:remove = " gpsd gps-utils connman wvdial ppp modemmanager "
 IMAGE_ROOTFS_SIZE = "487424"
+
+BALENA_BOOT_SIZE:iotdin-imx8p-d1d8 = "40960"
+BALENA_STATE_SIZE:iotdin-imx8p-d1d8 = "20480"
+BALENA_BOOT_SIZE:iotdin-imx8p = "40960"
+BALENA_STATE_SIZE:iotdin-imx8p = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.