### PR TITLE
.github/workflows: Adapt to new repo name

### DIFF
--- a/.github/workflows/iotdin-imx8p-d1d8.yml
+++ b/.github/workflows/iotdin-imx8p-d1d8.yml
@@ -108,7 +108,7 @@ jobs:
     with:
       machine: iotdin-imx8p-d1d8
       # Hardcode the device repo in case this workflow is called by another workflow
-      device-repo: balena-os/balena-iotdin-imx8p
+      device-repo: balena-os/balena-compulab-imx8mp
       device-repo-ref: ${{ inputs.device-repo-ref || github.ref }}
       test_matrix: ${{ needs.get_inputs.outputs.test_matrix }}
       # Allow manual workflow runs to force finalize without checking previous test runs

--- a/.github/workflows/iotdin-imx8p.yml
+++ b/.github/workflows/iotdin-imx8p.yml
@@ -106,7 +106,7 @@ jobs:
     with:
       machine: iotdin-imx8p
       # Hardcode the device repo in case this workflow is called by another workflow
-      device-repo: balena-os/balena-iotdin-imx8p
+      device-repo: balena-os/balena-compulab-imx8mp
       device-repo-ref: ${{ inputs.device-repo-ref || github.ref }}
       test_matrix: ${{ needs.get_inputs.outputs.test_matrix }}
       # Allow manual workflow runs to force finalize without checking previous test runs


### PR DESCRIPTION
The repo has been renamed from balena-iotdin-imx8p to balena-compulab-imx8mp

Changelog-entry: Adapt .github/workflows to repo name change